### PR TITLE
Add Tkinter dashboard for World Bank data

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,80 @@
+import json
+import pathlib
+import tkinter as tk
+from tkinter import ttk
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+import requests
+
+CACHE_DIR = pathlib.Path(__file__).resolve().parent / "cache"
+CACHE_DIR.mkdir(exist_ok=True)
+
+INDICATORS = {
+    "GDP": "NY.GDP.MKTP.CD",
+    "CO2": "EN.ATM.CO2E.PC",
+}
+
+def get_indicator_data(country, indicator, cache_dir=CACHE_DIR):
+    """Return DataFrame of indicator data for the given country."""
+    fname = cache_dir / f"{country}_{indicator}.csv"
+    if fname.exists():
+        df = pd.read_csv(fname)
+    else:
+        url = f"https://api.worldbank.org/v2/country/{country}/indicator/{indicator}?format=json&per_page=1000"
+        res = requests.get(url, timeout=10)
+        res.raise_for_status()
+        data = res.json()[1]
+        df = pd.DataFrame(data)[["date", "value"]]
+        df.to_csv(fname, index=False)
+    df = df.dropna()
+    df["date"] = df["date"].astype(int)
+    return df.sort_values("date")
+
+
+class Dashboard(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("World Bank Dashboard")
+        self.country_var = tk.StringVar(value="JPN")
+        self.indicator_var = tk.StringVar(value="GDP")
+        self.chart_type = tk.StringVar(value="line")
+        self._create_widgets()
+        self._create_plot()
+
+    def _create_widgets(self):
+        frm = ttk.Frame(self)
+        frm.pack(side=tk.TOP, fill=tk.X)
+        ttk.Label(frm, text="Country code").pack(side=tk.LEFT)
+        ttk.Entry(frm, textvariable=self.country_var, width=6).pack(side=tk.LEFT)
+        ttk.Label(frm, text="Indicator").pack(side=tk.LEFT)
+        ttk.Combobox(frm, textvariable=self.indicator_var, values=list(INDICATORS.keys()), width=5).pack(side=tk.LEFT)
+        ttk.Radiobutton(frm, text="Line", variable=self.chart_type, value="line", command=self.update_plot).pack(side=tk.LEFT)
+        ttk.Radiobutton(frm, text="Scatter", variable=self.chart_type, value="scatter", command=self.update_plot).pack(side=tk.LEFT)
+        ttk.Button(frm, text="Plot", command=self.update_plot).pack(side=tk.LEFT)
+
+    def _create_plot(self):
+        self.fig, self.ax = plt.subplots(figsize=(5, 4))
+        self.canvas = FigureCanvasTkAgg(self.fig, master=self)
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+        self.update_plot()
+
+    def update_plot(self):
+        code = self.country_var.get()
+        ind_key = self.indicator_var.get()
+        indicator = INDICATORS[ind_key]
+        df = get_indicator_data(code, indicator)
+        self.ax.clear()
+        if self.chart_type.get() == "line":
+            self.ax.plot(df["date"], df["value"], marker="o")
+        else:
+            self.ax.scatter(df["date"], df["value"])
+        self.ax.set_title(f"{code} {ind_key}")
+        self.ax.set_xlabel("Year")
+        self.ax.set_ylabel(ind_key)
+        self.fig.tight_layout()
+        self.canvas.draw()
+
+if __name__ == "__main__":
+    Dashboard().mainloop()

--- a/test_dashboard.py
+++ b/test_dashboard.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch, Mock
+import pandas as pd
+tempfile = __import__('tempfile')
+from pathlib import Path
+
+from dashboard import get_indicator_data
+
+SAMPLE_JSON = [
+    {"date": "2020", "value": 1},
+    {"date": "2019", "value": None},
+    {"date": "2018", "value": 2},
+]
+
+class TestGetIndicatorData(unittest.TestCase):
+    def test_load_from_cache(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "JPN_NY.GDP.MKTP.CD.csv"
+            pd.DataFrame(SAMPLE_JSON).to_csv(p, index=False)
+            with patch('dashboard.requests.get') as mock_get:
+                df = get_indicator_data('JPN', 'NY.GDP.MKTP.CD', cache_dir=Path(d))
+                self.assertFalse(mock_get.called)
+                self.assertEqual(len(df), 2)
+
+    def test_fetch_from_api(self):
+        with tempfile.TemporaryDirectory() as d:
+            mock_resp = Mock()
+            mock_resp.json.return_value = [None, SAMPLE_JSON]
+            mock_resp.raise_for_status = lambda: None
+            with patch('dashboard.requests.get', return_value=mock_resp) as mock_get:
+                df = get_indicator_data('JPN', 'NY.GDP.MKTP.CD', cache_dir=Path(d))
+                mock_get.assert_called_once()
+                self.assertTrue((Path(d) / 'JPN_NY.GDP.MKTP.CD.csv').exists())
+                self.assertEqual(list(df['date']), [2018, 2020])
+
+    def test_sorted(self):
+        with tempfile.TemporaryDirectory() as d:
+            mock_resp = Mock()
+            mock_resp.json.return_value = [None, SAMPLE_JSON]
+            mock_resp.raise_for_status = lambda: None
+            with patch('dashboard.requests.get', return_value=mock_resp):
+                df = get_indicator_data('JPN', 'NY.GDP.MKTP.CD', cache_dir=Path(d))
+                self.assertEqual(list(df['date']), sorted(df['date']))
+
+    def test_dropna(self):
+        with tempfile.TemporaryDirectory() as d:
+            mock_resp = Mock()
+            mock_resp.json.return_value = [None, SAMPLE_JSON]
+            mock_resp.raise_for_status = lambda: None
+            with patch('dashboard.requests.get', return_value=mock_resp):
+                df = get_indicator_data('JPN', 'NY.GDP.MKTP.CD', cache_dir=Path(d))
+                self.assertFalse(df['value'].isna().any())
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add `dashboard.py` with Tkinter GUI using pandas and Matplotlib
- fetch GDP and CO2 data with optional CSV caching
- add `test_dashboard.py` with four unit tests

## Testing
- `flake8 dashboard.py test_dashboard.py` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*